### PR TITLE
Raise NameError and TypeError

### DIFF
--- a/x11/xfce4-screensaver/files/patch-src_xfce4-screensaver-configure
+++ b/x11/xfce4-screensaver/files/patch-src_xfce4-screensaver-configure
@@ -1,0 +1,21 @@
+--- src/xfce4-screensaver-configure.orig	2019-08-03 17:11:05 UTC
++++ src/xfce4-screensaver-configure
+@@ -711,16 +711,15 @@ if __name__ == "__main__":
+     args = parser.parse_args()
+ 
+     graphical = not args.check
++    primary = _("Unable to configure screensaver")
+ 
+     saver = args.screensaver
+     if saver is None:
+-        show_fatal(primary, _("Screensaver required.") % saver)
++        show_fatal(primary, _("Screensaver required."))
+         sys.exit(1)
+ 
+     if saver.startswith("screensavers-"):
+         saver = saver[13:]
+-
+-    primary = _("Unable to configure screensaver")
+ 
+     fname = get_filename(saver)
+     if fname is None:


### PR DESCRIPTION
I submitted a patch [1] for xfce4-screensaver-configure. It fixes NameError and TypeError traceback.

Normally users launch this executable through xfce4-screensaver-preferences (not in command line), so they are not directly affected.

Note: the release 0.1.7 is not impacted.

[1] https://bugzilla.xfce.org/show_bug.cgi?id=15830