### PR TITLE
Switch to the Greybird's xfwm4 theme by default

### DIFF
--- a/sysutils/xfce4-settings/pkg-message
+++ b/sysutils/xfce4-settings/pkg-message
@@ -20,8 +20,8 @@ theme.
 
 Or launch these command in a shell:
   xfconf-query -c xsettings -p /Net/ThemeName -t string -s "Greybird"
-  xfconf-query -c xfwm4 -p /general/theme -t string -s "Greybird"
   xfconf-query -c xsettings -p /Net/IconThemeName -t string -s "elementary-xfce"
+  xfconf-query -c xfwm4 -p /general/theme -t string -s "Greybird"
 EOD
 }
 ]

--- a/sysutils/xfce4-settings/pkg-message
+++ b/sysutils/xfce4-settings/pkg-message
@@ -15,8 +15,12 @@ menu, under settings/appearence, and go to 'Style' tab to select
 the greybird theme and then to the 'Icons' tab to select the
 xfce-elementary icons.
 
+Then go to 'Window Manager' or launch 'xfwm4-settings' select greybird
+theme.
+
 Or launch these command in a shell:
   xfconf-query -c xsettings -p /Net/ThemeName -t string -s "Greybird"
+  xfconf-query -c xfwm4 -p /general/theme -t string -s "Greybird"
   xfconf-query -c xsettings -p /Net/IconThemeName -t string -s "elementary-xfce"
 EOD
 }

--- a/x11-wm/xfce4-wm/Makefile
+++ b/x11-wm/xfce4-wm/Makefile
@@ -44,4 +44,8 @@ NLS_USES=		gettext-runtime
 STARTUP_CONFIGURE_ENABLE=	startup-notification
 STARTUP_LIB_DEPENDS=	libstartup-notification-1.so:x11/startup-notification
 
+post-patch:
+	@${REINPLACE_CMD} -e 's|Default|Greybird|' \
+		${WRKSRC}/settings-dialogs/xfwm4-settings.c
+
 .include <bsd.port.mk>


### PR DESCRIPTION
As we switched to the Greybird theme, xfwm4 still uses default theme. This pull request changes default value.

Now Greybird is default theme for:
- Gtk applications (post-patch target in sysutils/xfce4-settings)
- xfwm4 (post-patch target in x11-wm/xfce4-wm)